### PR TITLE
fix link to screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GPU accelerated non local means (NLM) denoising plugin for napari (WIP)
 * currently only supports single-channel 2D or 3D images
 * requires a OpenCL capable GPU
 
-![Screenshot](images/screenshot.jpg)
+![Screenshot](https://github.com/maweigert/napari-nlm/raw/main/images/screenshot.jpg)
 
 
 ## Installation


### PR DESCRIPTION
Hi Martin @maweigert ,

with this little PR, the screenshot should become visible on the [napari hub page of your plugin](https://www.napari-hub.org/plugins/napari-nlm) after the next release.

Thanks!

Best,
Robert